### PR TITLE
Use current Place's icon for the Activity's large image

### DIFF
--- a/source/client/StudioRP.lua
+++ b/source/client/StudioRP.lua
@@ -24,7 +24,7 @@ do
 end
 
 local placeIcon = nil
-do
+if game.PlaceId ~= 0 then
 	local success, response = pcall(function()
 		-- TODO: Expand the HttpClient to cover Roblox GET web requests.
 		-- Additionally, remove the hardcoding on this PATH once HttpClient is expanded.
@@ -51,6 +51,7 @@ function StudioRP.new(plugin: Plugin)
 	local mainActivity = Activity.new(DateTime.now())
 		:SetLargeImage(placeIcon or "studio_logo")
 		:SetDetails(`Workspace: {gameName}`)
+		:SetSmallImage(placeIcon and "bordered_studio_logo")
 	local playtestActivity
 
 	self._heartbeat = coroutine.create(function()
@@ -64,9 +65,10 @@ function StudioRP.new(plugin: Plugin)
 
 			if RunService:IsRunning() then
 				playtestActivity = Activity.new(DateTime.now())
+					:SetLargeImage(placeIcon or "studio_logo")
 					:SetState("Testing")
 					:SetDetails(`Workspace: {gameName}`)
-				--:SetSmallImage("playtest_icon")
+					:SetSmallImage(placeIcon and "bordered_studio_logo")
 
 				plugin:SetSetting("LastPlaytestTime", math.round(tick()))
 			elseif StudioService.ActiveScript then

--- a/source/client/StudioRP.lua
+++ b/source/client/StudioRP.lua
@@ -1,3 +1,4 @@
+local HttpService = game:GetService("HttpService")
 local MarketplaceService = game:GetService("MarketplaceService")
 local RunService = game:GetService("RunService")
 local StudioService = game:GetService("StudioService")
@@ -22,6 +23,22 @@ do
 	end
 end
 
+local placeIcon = nil
+do
+	local success, response = pcall(function()
+		-- TODO: Expand the HttpClient to cover Roblox GET web requests.
+		-- Additionally, remove the hardcoding on this PATH once HttpClient is expanded.
+		local url = `https://thumbnails.roproxy.com/v1/places/gameicons?placeIds={game.PlaceId}&returnPolicy=PlaceHolder&size=420x420&format=Webp&isCircular=false`
+		return HttpService:JSONDecode(HttpService:GetAsync(url))
+	end)
+
+	if success and response and response.data and response.data[1] then
+		placeIcon = response.data[1].imageUrl
+	else
+		warn("[StudioRP] Could not retrieve Place Icon! " .. tostring(response))
+	end
+end
+
 local StudioRP = {}
 
 function StudioRP.new(plugin: Plugin)
@@ -32,7 +49,7 @@ function StudioRP.new(plugin: Plugin)
 	}, {__index = StudioRP})
 
 	local mainActivity = Activity.new(DateTime.now())
-		:SetLargeImage("studio_logo")
+		:SetLargeImage(placeIcon or "studio_logo")
 		:SetDetails(`Workspace: {gameName}`)
 	local playtestActivity
 


### PR DESCRIPTION
# Summary
This is a short and sweet addition that changes the Activity's large image to the current Place's icon. The Roblox Studio icon has been moved over to the Activity's small image, but will backtrack to the large image if the current Place lacks a proper icon.
The proxy URL necessary for retrieving the Place icon's CDN link has been hardcoded and will need to be shifted elsewhere with an expansion of the HttpClient.